### PR TITLE
Restore Dynamic View for non-Docker components

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -379,6 +379,7 @@ Installing this ZenPack will add the following items to your Zenoss system.
 == Changes ==
 
 ;2.0.2
+* Fix disabling of Dynamic View of non-Docker components. (ZPS-703)
 
 ;2.0.1
 ; Disable container status monitoring by default. (ZEN-24043)

--- a/ZenPacks/zenoss/Docker/zenpacklib.py
+++ b/ZenPacks/zenoss/Docker/zenpacklib.py
@@ -1882,7 +1882,7 @@ class ZenPackSpec(Spec):
         if service_view_metatypes:
             return (
                 "Zenoss.nav.appendTo('Component', [{{\n"
-                "    id: 'subcomponent_view',\n"
+                "    id: '{zenpack_id_prefix}_subcomponent_view',\n"
                 "    text: _t('Dynamic View'),\n"
                 "    xtype: 'dynamicview',\n"
                 "    relationshipFilter: 'impacted_by',\n"
@@ -1895,6 +1895,7 @@ class ZenPackSpec(Spec):
                 "    }}\n"
                 "}}]);\n"
                 ).format(
+                    zenpack_id_prefix=self.id_prefix,
                     cases=' '.join(
                         "case '{}': return true;".format(x)
                         for x in service_view_metatypes))


### PR DESCRIPTION
The Docker ZenPack was a causing a problem with all other ZenPacks where
their components that should have a Dynamic View available didn't. It
turns out the reason for this was that the Docker ZenPack doesn't
include a custom device type, so the component Dynamic View for the
Docker ZenPack was being added to all devices in the system. Depending
on the order in which JavaScript snippets were loaded, this would either
result in Docker containers not having a Dynamic View, or no components
other than Docker containers having a Dynamic View.

This fix namespaces the Dynamic View component to the ZenPack. This
allows both Docker containers, and all other components to have a
Dynamic View without stomping on each other.

This is a general fix that will go into the ZenPackLib ZenPack for the
future too.

Fixes ZPS-703.