### PR TITLE
Fix flare Message on dependency view tab

### DIFF
--- a/ZenPacks/zenoss/Docker/dynamicview.py
+++ b/ZenPacks/zenoss/Docker/dynamicview.py
@@ -33,11 +33,9 @@ class DeviceRelationsProvider(BaseRelationsProvider):
         device = self._adapted
 
         if type in (TAG_ALL, TAG_IMPACTS):
-            if not device.aqBaseHasAttr("docker_containers") and not device.aqBaseHasAttr("podman_containers"):
-                return
-
-            for container in device.docker_containers():
-                yield self.constructRelationTo(container, TAG_IMPACTS)
-
-            for container in device.podman_containers():
-                yield self.constructRelationTo(container, TAG_IMPACTS)
+            if device.aqBaseHasAttr("docker_containers"):
+                for container in device.docker_containers():
+                    yield self.constructRelationTo(container, TAG_IMPACTS)
+            if device.aqBaseHasAttr("podman_containers"):
+                for container in device.podman_containers():
+                    yield self.constructRelationTo(container, TAG_IMPACTS)


### PR DESCRIPTION
Fixes ZPS-8224.

Fixed flare Message on dependency view tab
for every device 'AttributeError: podman_containers'.